### PR TITLE
Reverse open issue logic

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,11 +87,10 @@ on:
 
 In the above, asking for the pull_request will actually open an issue with
 a link for you to click to start the process. If there are previous issues open
-with the same title (to update the same package) they will be closed. We could
-tweak this to do the opposite - to check for an open issue and not open a new one,
-if desired. You can also run this on a scheduled event,
-and this variant will look for changes in the spack remote packages. Thus, it's reccommended
-to run this action for pushes to main and on a schedule (without pull_request):
+with the same title (to update the same package) a new issue will not be opened. 
+You can also run this on a scheduled event, and this variant will look for 
+changes in the spack remote packages. Thus, it's reccommended to run this action 
+for pushes to main and on a schedule (without pull_request):
 
 
 ```yaml

--- a/update_package.py
+++ b/update_package.py
@@ -122,14 +122,13 @@ class SpackChangeRequest:
         """
         Submit an update or new package request by opening an issue on our own repo
         """
-        self.close_issues(title)
-
         title = "[package-update] request to update %s" % self.package
         body = "This is a request for an automated package update.\n\n" + yaml.dump(
             self.data
         )
         print(f"Title: {title}")
         print(body)
+        self.close_issues(title)
 
         # This is the url we assemble that will be provided in the issue to trigger an update workflow
         encoded_title = urllib.parse.quote(title)


### PR DESCRIPTION
The current logic looks for currently opened (equivalent) issues and closes them before opening a new issue. In practice because review is slow (and the updater will find changes and want to open a new issue) this is going to lead to a HUGE number of opened / closed issues (depending on how often it is run) so a better approach, implemented here, is simply to check for open issues, and if one is found, do not open a new one. We assume it would be redundant, and the developer is aware that the previous one is open (and not resolved yet).

Also it looks like my main is borked (not in sync here) and I need to re-create it locally! Oups.
